### PR TITLE
refactor: change vector_output() return type to CString

### DIFF
--- a/pg_extension/src/vector_type.rs
+++ b/pg_extension/src/vector_type.rs
@@ -12,9 +12,7 @@ use pgrx::pgrx_sql_entity_graph::metadata::Returns;
 use pgrx::pgrx_sql_entity_graph::metadata::ReturnsError;
 use pgrx::pgrx_sql_entity_graph::metadata::SqlMapping;
 use pgrx::pgrx_sql_entity_graph::metadata::SqlTranslatable;
-use pgrx::stringinfo::StringInfo;
 use pgrx::wrappers::rust_regtypein;
-use std::error::Error;
 use std::ffi::CStr;
 use std::ffi::CString;
 
@@ -113,12 +111,9 @@ fn vector_input(input: &CStr, _oid: pg_sys::Oid, type_modifier: i32) -> Vector {
 }
 
 #[pg_extern(immutable, strict, parallel_safe, requires = [ "shell_type" ])]
-fn vector_output(value: Vector) -> &'static CStr {
-    let mut s = StringInfo::new();
+fn vector_output(value: Vector) -> CString {
     let value_serialized_string = serde_json::to_string(&value).unwrap();
-    s.push_str(&value_serialized_string);
-    // SAFETY: We just constructed this StringInfo ourselves
-    unsafe { s.leak_cstr() }
+    CString::new(value_serialized_string).expect("there should be no NUL in the middle")
 }
 
 #[pg_extern(immutable, strict, parallel_safe, requires = [ "shell_type" ])]


### PR DESCRIPTION
Change the return type of `vector_output()` from `&'static CStr` to `CString` so that we don't need to leak memory.

The ideal implementation would be returning a `StringInfo` once `BoxRet` is implemented for it, `StringInfo` represents the memory allocated and managed by Postgres, and using it would mirror pgvecor's behavior:


https://github.com/pgvector/pgvector/blob/cfdcbd75d1283a94550515f5414acf8493be7c7e/src/vector.c#L293-L310