### PR TITLE
chore: improve error handling/message

### DIFF
--- a/pg_extension/src/vector_type.rs
+++ b/pg_extension/src/vector_type.rs
@@ -138,8 +138,8 @@ fn vector_modifier_input(list: pgrx::datum::Array<&CStr>) -> i32 {
 }
 
 #[pg_extern(immutable, strict, parallel_safe, requires = [ "shell_type" ])]
-fn vector_modifier_output(type_modifer: i32) -> CString {
-    CString::new(format!("({})", type_modifer)).expect("no NUL in the middle")
+fn vector_modifier_output(type_modifier: i32) -> CString {
+    CString::new(format!("({})", type_modifier)).expect("no NUL in the middle")
 }
 
 // create the actual type, specifying the input and output functions

--- a/pg_extension/src/vector_type.rs
+++ b/pg_extension/src/vector_type.rs
@@ -122,9 +122,16 @@ fn vector_modifier_input(list: pgrx::datum::Array<&CStr>) -> i32 {
         pgrx::error!("too many modifiers, expect 1")
     }
 
-    let modifier = list.get(0).unwrap().unwrap();
-    let Ok(dimension) = modifier.to_str().unwrap().parse::<u16>() else {
-        pgrx::error!("too many dimensions, expect [1, 65535]")
+    let modifier = list
+        .get(0)
+        .expect("should be Some as len = 1")
+        .expect("type modifier cannot be NULL");
+    let Ok(dimension) = modifier
+        .to_str()
+        .expect("expect type modifiers to be UTF-8 encoded")
+        .parse::<u16>()
+    else {
+        pgrx::error!("invalid dimension value, expect a number in range [1, 65535]")
     };
 
     dimension as i32

--- a/pg_extension/src/vector_type.rs
+++ b/pg_extension/src/vector_type.rs
@@ -139,7 +139,7 @@ fn vector_modifier_input(list: pgrx::datum::Array<&CStr>) -> i32 {
 
 #[pg_extern(immutable, strict, parallel_safe, requires = [ "shell_type" ])]
 fn vector_modifier_output(type_modifer: i32) -> CString {
-    CString::new(format!("({})", type_modifer)).unwrap()
+    CString::new(format!("({})", type_modifer)).expect("no NUL in the middle")
 }
 
 // create the actual type, specifying the input and output functions


### PR DESCRIPTION
### What does this PR do

1. Replace `unwrap()` with `expect()`
2. Improve the error message, when u16 parsing fails, the input is not necessarily a number, "too many dimensions" assumes it to be a number, so give it an update